### PR TITLE
if outputPath is not provided, no need to add / before finalFileName,…

### DIFF
--- a/index.js
+++ b/index.js
@@ -214,8 +214,9 @@ class ConcatPlugin {
         Object.entries(allFiles).forEach(([name, file]) => {
             concatSource.add(new OriginalSource(file, name));
         });
-        compilation.emitAsset(`${this.settings.outputPath}/${this.finalFileName}`, concatSource);
-
+        const filePathAsset = this.settings.outputPath ? `${this.settings.outputPath}/${this.finalFileName}` : this.finalFileName;
+        compilation.emitAsset(filePathAsset, concatSource);
+        
         this.needCreateNewFile = false;
     }
 


### PR DESCRIPTION
If outputPath is not provided, there should be a / in front of finalFileName.  It will end up to be //finalFileName on the final file